### PR TITLE
Making changes to allow for a build against UHD 003.010.0xx

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.anhonesteffort.uhd</groupId>
 	<artifactId>uhd-java</artifactId>
-	<version>003.009.005</version>
+	<version>003.010.001</version>
 
 	<properties>
 		<javacpp.jar>${org.bytedeco:javacpp:jar}</javacpp.jar> <!-- I complain though I shouldn't -->
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.bytedeco</groupId>
 			<artifactId>javacpp</artifactId>
-			<version>0.11</version>
+			<version>1.3</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
@@ -95,6 +95,7 @@
 								<argument>-jar</argument>       <argument>${javacpp.jar}</argument>
 								<argument>-classpath</argument> <argument>${project.build.outputDirectory}</argument>
 								<argument>-d</argument>         <argument>${project.build.outputDirectory}/</argument>
+								<argument>-Xcompiler</argument> <argument>-lboost_system</argument>
 							</arguments>
 						</configuration>
 					</execution>


### PR DESCRIPTION
There were problems linking up libboost for some reason so I've added an explicit compiler option to link it. It builds and tests out fine now.